### PR TITLE
MacOS: mark sokol linked frameworks as PUBLIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(SOKOL_HEADERS
     sokol/sokol_glue.h)
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     add_library(sokol STATIC sokol/sokol.m ${SOKOL_HEADERS})
-    target_link_libraries(sokol
+    target_link_libraries(sokol PUBLIC
         "-framework QuartzCore"
         "-framework Cocoa"
         "-framework MetalKit"


### PR DESCRIPTION
CMake 3.19.2 does not allow mixing "plain" and "keyword" calls to target_link_libraries.

Hi @floooh, thank you for making this starter-kit! I tried to set up a cross platform project like this with sokol a couple of months ago but couldn't quite wrangle it. I don't know enough about your library to know if this should be PUBLIC or PRIVATE (both work), but my version of CMake gives a hard error without it.

Aaand while I'm here, extra thanks for your blog posts. Your thoughts on library design, C, and reducing executable bloat are genuinely an inspiration to me. I would not have written the C code I have without that nudge!