### PR TITLE
Set Visual Studio startup project to demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ target_include_directories(sokol INTERFACE sokol)
 #=== EXECUTABLE: demo
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     add_executable(demo WIN32 demo.c)
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT demo)
 else()
     add_executable(demo demo.c)
 endif()


### PR DESCRIPTION
Fix startup project is ALL_BUILD which fails to produce demo.exe

I'm not very familiar with cmake. I just followed [this answer](https://stackoverflow.com/questions/7304625/how-do-i-change-the-startup-project-of-a-visual-studio-solution-via-cmake/37994396#37994396).
Limiting it to Windows makes sense to me.

Test
I removed and recreated my build directory and now my sln generates with demo as the startup project so I can just hit F5 and see the demo app.